### PR TITLE
Split simulation code into modules

### DIFF
--- a/simple_network_sim/common.py
+++ b/simple_network_sim/common.py
@@ -1,0 +1,10 @@
+# CurrentlyInUse
+def generateMeanPlot(listOfPlots):
+    meanForPlot = []
+    # print(listOfPlots)
+    for i in range(len(listOfPlots[0])):
+        sumTot = 0
+        for j in range(len(listOfPlots)):
+            sumTot = sumTot + listOfPlots[j][i]
+        meanForPlot.append(float(sumTot)/len(listOfPlots))
+    return meanForPlot

--- a/simple_network_sim/network_of_individuals.py
+++ b/simple_network_sim/network_of_individuals.py
@@ -1,0 +1,241 @@
+import random
+from collections import Counter
+
+import networkx as nx
+
+
+# NotCurrentlyInUseByCoreModel
+def doSetup(G, dictOfStates):
+    dictOfStates[0] = {}
+    for guy in G.nodes():
+        dictOfStates[0][guy] = 'S'
+
+
+# NotCurrentlyInUse
+def chooseFromDistrib(distrib):
+    sumSoFar = 0
+    thisLuck = random.random()
+    for value in distrib:
+        sumSoFar = sumSoFar + distrib[value]
+        if thisLuck <= sumSoFar:
+            return value
+    print('Something has gone wrong - no next state was returned.  Choosing arbitrarily')
+    return min(distrib.keys())
+
+
+# NotCurrentlyInUseByCoreModel
+def readParameters(filename):
+    parametersDictionary = {}
+    try:
+        for line in open(filename, 'r'):
+            split = line.strip().split(":")
+            parametersDictionary[split[0].strip()] = float(split[1].strip())
+    except IndexError:
+        raise Exception(f"Error: Malformed input \"{line.rstrip()}\" in {filename}") from None
+    return parametersDictionary
+
+
+# NotCurrentlyInUseByCoreModel
+def checkForParameters(dictOfParams, ageStructured):
+    ageStructParams = ['e_escape_young', 'a_escape_young', 'a_to_i_young', 'a_to_r_young', 'i_escape_young',
+                       'i_to_d_young', 'i_to_h_young', 'h_escape_young', 'h_to_d_young',
+                       'e_escape_mature', 'a_escape_mature', 'a_to_i_mature', 'a_to_r_mature', 'i_escape_mature',
+                       'i_to_d_mature', 'i_to_h_mature', 'h_escape_mature', 'h_to_d_mature',
+                       'e_escape_old', 'a_escape_old', 'a_to_i_old', 'a_to_r_old', 'i_escape_old', 'i_to_d_old',
+                       'i_to_h_old', 'h_escape_old', 'h_to_d_old']
+    vanillaParams = ['e_escape', 'a_escape', 'a_to_i', 'i_escape', 'i_to_d', 'i_to_h', 'h_escape', 'h_to_d']
+
+    if ageStructured:
+        for param in ageStructParams:
+            if param not in dictOfParams:
+                print = ("ERROR: missing parameter " + str(param))
+                return False
+    else:
+        for param in vanillaParams:
+            if param not in dictOfParams:
+                print = ("ERROR: missing parameter " + str(param))
+                return False
+    return True
+
+
+# NotCurrentlyInUseByCoreModel
+# Simplest sensible model: no age classes, uniform transitions between states
+# each vertex will have a state at each timestep
+def doProgression(dictOfStates, currentTime):
+    # currentTime = max(dictOfStates.values())
+    nextTime = currentTime + 1
+    currStates = dictOfStates[currentTime]
+    dictOfStates[nextTime] = {}
+
+    for vertex in currStates:
+        # get the state, then then possibilities
+        state = currStates[vertex]
+        if state == 'R' or state == 'D':
+            dictOfStates[nextTime][vertex] = state
+        elif state != 'S':
+            dictOfStates[nextTime][vertex] = chooseFromDistrib(fromStateTrans[state])
+        else:
+            dictOfStates[nextTime][vertex] = dictOfStates[currentTime][vertex]
+
+
+# NotCurrentlyInUseByCoreModel
+def doInfection(graph, dictOfStates, currentTime, genericInfectionProb):
+    newInfected = []
+    for vertex in dictOfStates[currentTime]:
+
+        if dictOfStates[currentTime][vertex] == 'I' or dictOfStates[currentTime][vertex] == 'A':
+            neighbours = list(graph.neighbors(vertex))
+            for neigh in neighbours:
+                if dictOfStates[currentTime][neigh] == 'S':
+                    if 'weight' not in graph[vertex][neigh]:
+                        probabilityOfInfection = genericInfectionProb
+                    else:
+                        probabilityOfInfection = graph[vertex][neigh]['weight']
+                    thisLuck = random.random()
+                    if thisLuck <= probabilityOfInfection:
+                        newInfected.append(neigh)
+    for fella in newInfected:
+        dictOfStates[currentTime + 1][fella] = 'E'
+
+
+# NotCurrentlyInUseByCoreModel
+def prettyPrint(dictOfStates, time):
+    states = ['S']
+    stateString = 'S,'
+    for state in fromStateTrans:
+        states.append(state)
+        stateString = stateString + state + ","
+    print(stateString)
+
+    counts = Counter(dictOfStates[time].values())
+    print(counts)
+
+
+# NotCurrentlyInUseByCoreModel
+def countInfections(dictOfStates, time):
+    counts = Counter(dictOfStates[time].values())
+    sumBoth = 0
+    if 'I' in counts:
+        sumBoth = sumBoth + counts['I']
+    if 'A' in counts:
+        sumBoth = sumBoth + counts['A']
+    return sumBoth
+
+
+# NotCurrentlyInUseByCoreModel
+def basicSimulation(graph, numInfected, timeHorizon, genericInfection):
+    timeSeriesInfection = []
+    # choose a random set of initially infected
+    infected = random.choices(list(graph.nodes()), k=numInfected)
+    print(infected)
+    dictOfStates = {}
+    doSetup(graph, dictOfStates)
+    for vertex in infected:
+        dictOfStates[0][vertex] = 'I'
+
+    for time in range(timeHorizon):
+        doProgression(dictOfStates, time)
+        doInfection(graph, dictOfStates, time, genericInfection)
+        timeSeriesInfection.append(countInfections(dictOfStates, time))
+
+    return timeSeriesInfection
+
+
+# NotCurrentlyInUseByCoreModel
+def generateHouseholds(numHouseholds, radius, locations, householdMembership, withinNeighbourhood):
+    # generate a random geometric graph for households in range:
+    randomGeometric = nx.random_geometric_graph(numHouseholds, radius)
+    householdSizes = [1, 1, 2, 2, 2, 2, 3, 4, 4, 3, 3, 2]
+    householdToMem = {}
+    wholeGraph = nx.MultiGraph()
+    for household in list(randomGeometric.nodes()):
+        householdToMem[household] = []
+        numMembers = random.choice(householdSizes)
+        theMembers = []
+        for member in range(numMembers):
+            theMembers.append((household, member))
+            wholeGraph.add_node((household, member))
+            householdToMem[household].append((household, member))
+        for member in theMembers:
+            for secondMem in theMembers:
+                if member != secondMem:
+                    wholeGraph.add_edge(member, secondMem)
+    for household in list(randomGeometric.nodes()):
+        neighbourHouse = list(randomGeometric.neighbors(household))
+        withinNeighbourhood[household] = neighbourHouse
+        for neighbour in neighbourHouse:
+            for fella in householdToMem[household]:
+                for guy in householdToMem[neighbour]:
+                    if (fella, guy) not in wholeGraph.edges():
+                        wholeGraph.add_edge(fella, guy)
+    householdMembership = householdToMem
+    return wholeGraph
+
+
+# NotCurrentlyInUseByCoreModel
+def generateHouseholdsAggregateGraph(numHouseholds, radius):
+    # generate a random geometric graph for households in range:
+    randomGeometric = nx.random_geometric_graph(numHouseholds, radius)
+    return randomGeometric
+
+
+# NotCurrentlyInUseByCoreModel
+def addIllicitEdges(existingGraph, numberEdges):
+    for i in range(numberEdges):
+        listOfTwo = list(random.sample(list(existingGraph.nodes()), 2))
+        existingGraph.add_edge(listOfTwo[0], listOfTwo[1])
+
+
+# NotCurrentlyInUseByCoreModel
+def generateIllicitEdges(existingGraph, numberEdges):
+    newEdges = []
+    for i in range(numberEdges):
+        listOfTwo = list(random.sample(list(existingGraph.nodes()), 2))
+        existingGraph.add_edge(listOfTwo[0], listOfTwo[1])
+        newEdges.append((listOfTwo[0], listOfTwo[1]))
+    return newEdges
+
+
+# NotCurrentlyInUseByCoreModel
+# note function is not finished
+# will eventually generate edges between and within households
+def generateChildcareEdges(numInEach, numGroups, graph, householdWithin, nearHouseholds):
+    print('WARNING - FUNCTION NOT PROPERLY FINISHED YET - generateChildcareEdges')
+    inAGroup = []
+
+    seeds = random.sample(list(graph.nodes()), numGroups)
+    inAGroup.extend(seeds)
+
+    for start in seeds:
+        remainingChoice = []
+        for fella in graph.nodes():
+            if fella not in inAGroup:
+                remainingChoice.append(fella)
+        adds = random.sample(remainingChoice, numInEach - 1)
+        inAGroup.append(adds)
+
+
+# NotCurrentlyInUseByCoreModel
+# for now all edges get the same weight
+# The graph here is the geometric graph
+def generateChildcareEdgesAggregate(graph, numGroups, sizeGroups):
+    strongEdges = []
+    inAGroup = []
+
+    seeds = random.sample(list(graph.nodes()), numGroups)
+    inAGroup.extend(seeds)
+    for start in seeds:
+        remainingChoice = []
+        for fella in list(graph.neighbors(start)):
+            if fella not in inAGroup:
+                remainingChoice.append(fella)
+        adds = random.sample(remainingChoice, min(sizeGroups - 1, len(remainingChoice)))
+        inAGroup.append(adds)
+        for item in adds:
+            strongEdges.append((start, item))
+            strongEdges.append((item, start))
+            for item2 in adds:
+                strongEdges.append((item2, item))
+                strongEdges.append((item, item2))
+
+    return strongEdges

--- a/simple_network_sim/network_of_populations.py
+++ b/simple_network_sim/network_of_populations.py
@@ -1,23 +1,6 @@
-import networkx as nx
-import random
-import sys
-from collections import Counter
-import matplotlib.pyplot as plt
-import json
-
-
-compartments = {}
-compNames = ['S', 'E', 'A', 'I', 'H', 'R', 'D']
-
-# NotCurrentlyInUseByCoreModel
-def doSetup(G, dictOfStates):
-    dictOfStates[0] = {}
-    for guy in G.nodes():
-        dictOfStates[0][guy] = 'S'
-        
-# CurrentlyInUse         
-#  This needs amendment to have different node populations and age structure
-#  Right now it is a framework function, to allow ongoing dev - uniform age structure in each, 
+# NotCurrentlyInUse
+# This needs amendment to have different node populations and age structure
+# Right now it is a framework function, to allow ongoing dev - uniform age structure in each,
 def doSetupAgeStruct(G, dictOfStates, numInside, ages, states):
     dictOfStates[0] = {}
     for guy in G.nodes():  
@@ -28,38 +11,6 @@ def doSetupAgeStruct(G, dictOfStates, numInside, ages, states):
             internalState[(age, 'S')] = numInside
         dictOfStates[0][guy] = internalState
     return dictOfStates
-
-
-# NotCurrentlyInUseByCoreModel
-def readParameters(filename):
-    parametersDictionary = {}
-    try:
-        for line in open(filename, 'r'):
-            split = line.strip().split(":")
-            parametersDictionary[split[0].strip()] = float(split[1].strip())
-    except IndexError:
-        raise Exception(f"Error: Malformed input \"{line.rstrip()}\" in {filename}") from None
-    return parametersDictionary
-
-
-# NotCurrentlyInUseByCoreModel
-def checkForParameters(dictOfParams, ageStructured):
-    ageStructParams = ['e_escape_young', 'a_escape_young', 'a_to_i_young', 'a_to_r_young', 'i_escape_young', 'i_to_d_young', 'i_to_h_young', 'h_escape_young', 'h_to_d_young',
-                       'e_escape_mature', 'a_escape_mature', 'a_to_i_mature', 'a_to_r_mature', 'i_escape_mature', 'i_to_d_mature', 'i_to_h_mature', 'h_escape_mature', 'h_to_d_mature',
-                        'e_escape_old', 'a_escape_old', 'a_to_i_old', 'a_to_r_old', 'i_escape_old', 'i_to_d_old', 'i_to_h_old', 'h_escape_old', 'h_to_d_old']
-    vanillaParams = ['e_escape', 'a_escape', 'a_to_i', 'i_escape', 'i_to_d', 'i_to_h', 'h_escape', 'h_to_d']
-    
-    if ageStructured:
-        for param in ageStructParams:
-            if param not in dictOfParams:
-                print =("ERROR: missing parameter " + str(param))
-                return False
-    else:
-        for param in vanillaParams:
-            if param not in dictOfParams:
-                print =("ERROR: missing parameter " + str(param))
-                return False
-    return True    
 
 
 # CurrentlyInUse
@@ -82,79 +33,7 @@ def setUpParametersAges(dictByAge):
         ageToStateTrans[age] = {}
         ageToStateTrans[age] = setUpParametersVanilla(dictByAge[age])
     return ageToStateTrans
-    
 
-# CurrentlyInUse
-def chooseFromDistrib(distrib):
-    sumSoFar = 0
-    thisLuck = random.random()
-    for value in distrib:
-        sumSoFar = sumSoFar + distrib[value]
-        if thisLuck <= sumSoFar:
-            return value
-    print('Something has gone wrong - no next state was returned.  Choosing arbitrarily')
-    return min(distrib.keys())
-
-
-# NotCurrentlyInUseByCoreModel
-# Simplest sensible model: no age classes, uniform transitions between states
-# each vertex will have a state at each timestep 
-def doProgression(dictOfStates, currentTime):
-    # currentTime = max(dictOfStates.values())
-    nextTime = currentTime +1
-    currStates = dictOfStates[currentTime]
-    dictOfStates[nextTime] = {}
-    
-    for vertex in currStates:
-       # get the state, then then possibilities
-       state = currStates[vertex]
-       if state =='R' or state == 'D':
-           dictOfStates[nextTime][vertex] = state
-       elif state != 'S': 
-           dictOfStates[nextTime][vertex] = chooseFromDistrib(fromStateTrans[state])
-       else:
-           dictOfStates[nextTime][vertex] = dictOfStates[currentTime][vertex]
-
-# NotCurrentlyInUseByCoreModel
-def doInfection(graph, dictOfStates, currentTime, genericInfectionProb):
-    newInfected = []
-    for vertex in dictOfStates[currentTime]:
-
-        if dictOfStates[currentTime][vertex] == 'I' or dictOfStates[currentTime][vertex] == 'A':
-            neighbours = list(graph.neighbors(vertex))
-            for neigh in neighbours:
-                    if dictOfStates[currentTime][neigh] == 'S':
-                        if 'weight' not in graph[vertex][neigh]:
-                            probabilityOfInfection = genericInfectionProb
-                        else:
-                            probabilityOfInfection = graph[vertex][neigh]['weight']
-                        thisLuck = random.random()
-                        if thisLuck <= probabilityOfInfection:
-                           newInfected.append(neigh)
-    for fella in newInfected:
-        dictOfStates[currentTime+1][fella] = 'E'
-    
-# NotCurrentlyInUseByCoreModel
-def prettyPrint(dictOfStates, time):
-    states = ['S']
-    stateString = 'S,'
-    for state in fromStateTrans:
-        states.append(state)
-        stateString = stateString + state + ","
-    print(stateString)
-    
-    counts = Counter(dictOfStates[time].values())
-    print(counts)
-    
-# NotCurrentlyInUseByCoreModel
-def countInfections(dictOfStates, time):
-    counts = Counter(dictOfStates[time].values())
-    sumBoth = 0
-    if 'I' in counts:
-       sumBoth = sumBoth + counts['I']
-    if 'A' in counts:
-        sumBoth = sumBoth + counts['A']
-    return sumBoth
 
 # CurrentlyInUse
 def countInfectionsAgeStructured(dictOfStates, time):
@@ -165,26 +44,8 @@ def countInfectionsAgeStructured(dictOfStates, time):
                 total = total + dictOfStates[time][node][(age, state)]
     return total
 
-# NotCurrentlyInUseByCoreModel
-def basicSimulation(graph, numInfected, timeHorizon, genericInfection):
-    
-    timeSeriesInfection = []
-    # choose a random set of initially infected
-    infected = random.choices(list(graph.nodes()), k=numInfected)
-    print(infected)
-    dictOfStates = {}
-    doSetup(graph, dictOfStates)
-    for vertex in infected:
-        dictOfStates[0][vertex] = 'I'
-    
-    for time in range(timeHorizon):
-        doProgression(dictOfStates, time)
-        doInfection(graph, dictOfStates, time, genericInfection)
-        timeSeriesInfection.append(countInfections(dictOfStates, time))
 
-    return timeSeriesInfection
-
-# CurrentlyInUse
+# NotCurrentlyInUse
 # this takes a dictionary of states at times at nodes, and returns a string
 # reporting the number of people in each state at each node at each time.
 # aggregates by age 
@@ -216,6 +77,7 @@ def basicReportingFunction(dictOfStates):
                 localString = localString + "," + str(elem)
             reportString = reportString+"\n" + str(node) + "," + str(state) + localString
     return reportString
+
 
 # CurrentlyInUse
 # amending this so that file I/O happens outside it 
@@ -256,119 +118,14 @@ def basicSimulationInternalAgeStructure(rand, graph, numInfected, timeHorizon, g
 
     return timeSeriesInfection
 
-# CurrentlyInUse
+
+# NotCurrentlyInUse
 def nodeUpdate(graph, dictOfStates, time, headString):
         print('\n\n===== BEGIN update 1 at time ' + str(time) + '=========' + headString)
         for node in list(graph.nodes()):
              print('Node ' + str(node)+ " E-A-I at mature " + str(dictOfStates[time][node][('m', 'E')]) + " " +str(dictOfStates[time][node][('m', 'A')]) + " " + str(dictOfStates[time][node][('m', 'I')]))
         print('===== END update 1 at time ' + str(time) + '=========')
 
-# NotCurrentlyInUseByCoreModel
-def generateHouseholds(numHouseholds, radius, locations, householdMembership, withinNeighbourhood):
-    # generate a random geometric graph for households in range:
-    randomGeometric = nx.random_geometric_graph(numHouseholds, radius)
-    householdSizes = [1, 1, 2, 2, 2, 2, 3, 4, 4, 3, 3, 2]
-    householdToMem = {}
-    wholeGraph = nx.MultiGraph()
-    for household in list(randomGeometric.nodes()):
-        householdToMem[household] = []
-        numMembers = random.choice(householdSizes)
-        theMembers = []
-        for member in range(numMembers):
-          theMembers.append((household, member))
-          wholeGraph.add_node((household, member))
-          householdToMem[household].append((household, member))
-        for member in theMembers:
-            for secondMem in theMembers:
-                if member != secondMem:
-                   wholeGraph.add_edge(member, secondMem)
-    for household in list(randomGeometric.nodes()):
-            neighbourHouse = list(randomGeometric.neighbors(household))
-            withinNeighbourhood[household] = neighbourHouse
-            for neighbour in neighbourHouse:
-                for fella in householdToMem[household]:
-                    for guy in householdToMem[neighbour]:
-                        if (fella, guy) not in wholeGraph.edges():
-                          wholeGraph.add_edge(fella, guy)
-    householdMembership = householdToMem
-    return wholeGraph
-
-# NotCurrentlyInUseByCoreModel
-def generateHouseholdsAggregateGraph(numHouseholds, radius):
-    # generate a random geometric graph for households in range:
-    randomGeometric = nx.random_geometric_graph(numHouseholds, radius)
-    return randomGeometric
-
-# NotCurrentlyInUseByCoreModel
-def addIllicitEdges(existingGraph, numberEdges):
-    for i in range(numberEdges):
-        listOfTwo = list(random.sample(list(existingGraph.nodes()), 2))
-        existingGraph.add_edge(listOfTwo[0], listOfTwo[1])
-
-# NotCurrentlyInUseByCoreModel
-def generateIllicitEdges(existingGraph, numberEdges):
-    newEdges = []
-    for i in range(numberEdges):
-        listOfTwo = list(random.sample(list(existingGraph.nodes()), 2))
-        existingGraph.add_edge(listOfTwo[0], listOfTwo[1])
-        newEdges.append((listOfTwo[0], listOfTwo[1]))
-    return newEdges
-        
-# NotCurrentlyInUseByCoreModel
-# note function is not finished
-# will eventually generate edges between and within households 
-def generateChildcareEdges(numInEach, numGroups, graph, householdWithin, nearHouseholds):
-    print('WARNING - FUNCTION NOT PROPERLY FINISHED YET - generateChildcareEdges')
-    inAGroup = []
-    
-    seeds = random.sample(list(graph.nodes()), numGroups)
-    inAGroup.extend(seeds)
-    
-    for start in seeds:
-        remainingChoice = []
-        for fella in graph.nodes():
-            if fella not in inAGroup:
-                remainingChoice.append(fella)
-        adds = random.sample(remainingChoice, numInEach -1)
-        inAGroup.append(adds)
-
-# NotCurrentlyInUseByCoreModel
-# for now all edges get the same weight
-# The graph here is the geometric graph 
-def generateChildcareEdgesAggregate(graph, numGroups, sizeGroups):
-    strongEdges = []
-    inAGroup = []
-    
-    seeds = random.sample(list(graph.nodes()), numGroups)
-    inAGroup.extend(seeds)
-    for start in seeds:
-        remainingChoice = []
-        for fella in list(graph.neighbors(start)):
-            if fella not in inAGroup:
-                remainingChoice.append(fella)
-        adds = random.sample(remainingChoice, min(sizeGroups -1, len(remainingChoice)))
-        inAGroup.append(adds)
-        for item in adds:
-            strongEdges.append((start, item))
-            strongEdges.append((item, start))
-            for item2 in adds:
-                strongEdges.append((item2, item))
-                strongEdges.append((item, item2))
-
-    return strongEdges
-    
-
-# CurrentlyInUse
-def generateMeanPlot(listOfPlots):
-    meanForPlot = []
-    # print(listOfPlots)
-    for i in range(len(listOfPlots[0])):
-        sumTot = 0
-        for j in range(len(listOfPlots)):
-            sumTot = sumTot + listOfPlots[j][i]
-        meanForPlot.append(float(sumTot)/len(listOfPlots))
-    return meanForPlot
-        
 
 # CurrentlyInUse
 def totalIndividuals(nodeState):
@@ -400,6 +157,7 @@ def getTotalSuscept(nodeState):
                 if state == 'S':
                         totalSusHere = totalSusHere + nodeState[(age, state)]
     return totalSusHere
+
 
 # CurrentlyInUse
 # fractional people will come out of this
@@ -523,6 +281,7 @@ def internalStateDiseaseUpdate(currentInternalStateDict, diseaseProgressionProbs
                 dictOfNewStates[(age, nextState)] = dictOfNewStates[(age, nextState)]  + numberInNext
     return dictOfNewStates
 
+
 # CurrentlyInUse
 def doInternalProgressionAllNodes(dictOfNodeInternalStates, currentTime, diseaseProgressionProbs):
     nextTime = currentTime +1
@@ -552,4 +311,3 @@ def setupInternalPopulations(graph, listOfStates, ages, dictOfPopulations):
         
     
     return dictOfInternalStates    
-    

--- a/simple_network_sim/sampleUseOfModel.py
+++ b/simple_network_sim/sampleUseOfModel.py
@@ -4,8 +4,9 @@ import sys
 from collections import Counter
 import matplotlib.pyplot as plt
 import json
-from . import covidAdapted as ss
-from . import loaders
+
+from . import common, network_of_populations as ss, loaders
+
     
  #  A bit of sample model operation.     
 
@@ -53,7 +54,7 @@ numTrials = 100
 for i in range(numTrials):
      basicPlots.append(ss.basicSimulationInternalAgeStructure(random.Random(), graph, numInfected, time, genericInfection, ageInfectionMatrix, ageToTrans, states))
 
-plt.plot(ss.generateMeanPlot(basicPlots), color = 'dodgerblue', label='basic')
+plt.plot(common.generateMeanPlot(basicPlots), color ='dodgerblue', label='basic')
 
 plt.savefig(sys.argv[4])
 

--- a/tests/regression/test_network_of_populations.py
+++ b/tests/regression/test_network_of_populations.py
@@ -2,17 +2,16 @@ import random
 
 import pytest
 
-from simple_network_sim import covidAdapted as ss
-from simple_network_sim import loaders
+from simple_network_sim import common, network_of_populations as np, loaders
 
 
 def test_basic_simulation(age_transitions, demographics, commute_moves, compartment_names, age_infection_matrix):
-    age_to_trans = ss.setUpParametersAges(loaders.readParametersAgeStructured(age_transitions))
+    age_to_trans = np.setUpParametersAges(loaders.readParametersAgeStructured(age_transitions))
     population = loaders.readPopulationAgeStructured(demographics)
     graph = loaders.genGraphFromContactFile(commute_moves)
-    states = ss.setupInternalPopulations(graph, compartment_names, list(age_to_trans.keys()), population)
+    states = np.setupInternalPopulations(graph, compartment_names, list(age_to_trans.keys()), population)
 
-    result = ss.basicSimulationInternalAgeStructure(
+    result = np.basicSimulationInternalAgeStructure(
         rand=random.Random(1),
         graph=graph,
         numInfected=10,
@@ -232,16 +231,16 @@ def test_basic_simulation(age_transitions, demographics, commute_moves, compartm
 def test_basic_simulation_100_runs(
     age_transitions, demographics, commute_moves, compartment_names, age_infection_matrix
 ):
-    age_to_trans = ss.setUpParametersAges(loaders.readParametersAgeStructured(age_transitions))
+    age_to_trans = np.setUpParametersAges(loaders.readParametersAgeStructured(age_transitions))
     population = loaders.readPopulationAgeStructured(demographics)
     graph = loaders.genGraphFromContactFile(commute_moves)
-    states = ss.setupInternalPopulations(graph, compartment_names, list(age_to_trans.keys()), population)
+    states = np.setupInternalPopulations(graph, compartment_names, list(age_to_trans.keys()), population)
 
     runs = []
     rand = random.Random(1)
     for _ in range(100):
         runs.append(
-            ss.basicSimulationInternalAgeStructure(
+            np.basicSimulationInternalAgeStructure(
                 rand=rand,
                 graph=graph,
                 numInfected=10,
@@ -252,7 +251,7 @@ def test_basic_simulation_100_runs(
                 dictOfStates=states,
             )
         )
-    result = ss.generateMeanPlot(runs)
+    result = common.generateMeanPlot(runs)
 
     expected = [
         0.0,

--- a/tests/unit/test_network_of_populations.py
+++ b/tests/unit/test_network_of_populations.py
@@ -1,0 +1,112 @@
+import copy
+import itertools
+import random
+
+import networkx as nx
+import pytest
+
+from simple_network_sim import network_of_populations as np, loaders
+
+
+def _count_people_per_region(state):
+    return [sum(region.values()) for region in state.values()]
+
+
+@pytest.mark.parametrize("seed", [2, 3])
+@pytest.mark.parametrize("num_infected", [0, 10])
+@pytest.mark.parametrize("generic_infection", [0.1, 1.0, 1.5])
+def test_basicSimulationInternalAgeStructure_invariants(
+    age_transitions,
+    demographics,
+    commute_moves,
+    compartment_names,
+    age_infection_matrix,
+    num_infected,
+    generic_infection,
+    seed,
+):
+    age_to_trans = np.setUpParametersAges(loaders.readParametersAgeStructured(age_transitions))
+    population = loaders.readPopulationAgeStructured(demographics)
+    graph = loaders.genGraphFromContactFile(commute_moves)
+    states = np.setupInternalPopulations(graph, compartment_names, list(age_to_trans.keys()), population)
+    old_graph = copy.deepcopy(graph)
+    old_age_to_trans = copy.deepcopy(age_to_trans)
+    initial_population = sum(_count_people_per_region(states[0])) + num_infected
+
+    np.basicSimulationInternalAgeStructure(
+        rand=random.Random(seed),
+        graph=graph,
+        numInfected=num_infected,
+        timeHorizon=50,
+        genericInfection=generic_infection,
+        ageInfectionMatrix=age_infection_matrix,
+        diseaseProgressionProbs=age_to_trans,
+        dictOfStates=states,
+    )
+
+    # population remains constant
+    assert all([sum(_count_people_per_region(state)) == pytest.approx(initial_population) for state in states.values()])
+
+    # the graph is unchanged
+    assert nx.is_isomorphic(old_graph, graph)
+
+    # infection matrix is unchanged
+    assert age_to_trans == old_age_to_trans
+
+
+def test_internalStateDiseaseUpdate_one_transition():
+    current_state = {("o", "E"): 100.0, ("o", "A"): 0.0}
+    probs = {"o": {"E": {"A": 0.4, "E": 0.6}, "A": {"A": 1.0}}}
+
+    new_state = np.internalStateDiseaseUpdate(current_state, probs)
+
+    assert new_state == {("o", "E"): 60.0, ("o", "A"): 40.0}
+
+
+def test_internalStateDiseaseUpdate_no_transitions():
+    current_state = {("o", "E"): 100.0, ("o", "A"): 0.0}
+    probs = {"o": {"E": {"E": 1.0}, "A": {"A": 1.0}}}
+
+    new_state = np.internalStateDiseaseUpdate(current_state, probs)
+
+    assert new_state == {("o", "E"): 100.0, ("o", "A"): 0.0}
+
+
+def test_internalStateDiseaseUpdate_progression_only():
+    current_state = {("o", "S"): 100.0, ("o", "E"): 0.0}
+    probs = {"o": {"S": {"E": 0.4, "S": 0.6}, "E": {"E": 1.0}}}
+
+    new_state = np.internalStateDiseaseUpdate(current_state, probs)
+
+    assert new_state == {("o", "S"): 100.0, ("o", "E"): 0.0}
+
+
+def test_doInternalProgressionAllNodes_create_new_state():
+    states = {0: {"region1": {("o", "E"): 100.0, ("o", "A"): 0.0}}}
+    probs = {"o": {"E": {"A": 0.4, "E": 0.6}, "A": {"A": 1.0}}}
+
+    np.doInternalProgressionAllNodes(states, 0, probs)
+
+    expected = {
+        0: {"region1": {("o", "E"): 100.0, ("o", "A"): 0.0}},
+        1: {"region1": {("o", "E"): 60.0, ("o", "A"): 40.0}},
+    }
+
+    assert states == expected
+
+
+def test_doInternalProgressionAllNodes_overwrite_state():
+    states = {
+        0: {"region1": {("o", "E"): 100.0, ("o", "A"): 0.0}},
+        1: {"region1": {("o", "E"): 100.0, ("o", "A"): 0.0}},
+    }
+    probs = {"o": {"E": {"A": 0.4, "E": 0.6}, "A": {"A": 1.0}}}
+
+    np.doInternalProgressionAllNodes(states, 0, probs)
+
+    expected = {
+        0: {"region1": {("o", "E"): 100.0, ("o", "A"): 0.0}},
+        1: {"region1": {("o", "E"): 60.0, ("o", "A"): 40.0}},
+    }
+
+    assert states == expected


### PR DESCRIPTION
I've took the liberty of creating also the common module with some generic functions that may be used by different modules. We can split that into more modules (or make it into a package) later if it starts to grow.

This PR also includes new unit tests on the network_of_populations. They are all passing. The coverage report I got is evidence that the split was done correctly. Also, based on that report, I've tagged a few other functions as "NotCurrentlyInUse": `basicReportingFunction`, `doSetupAgeStruct` and `nodeUpdate`.

I've tried to import all the modules required by network_of_individuals, but I couldn't find where `fromStateTrans` comes from, so I left it unresolved.

![image](https://user-images.githubusercontent.com/33273/82050286-c95d4e80-96af-11ea-98b1-1b42c1849b7b.png)
