### PR TITLE
Store csv files using LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.csv text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 *.csv text eol=lf
+


### PR DESCRIPTION
This ensures that all .csv files are stored using CRLF line endings.
Without this, git tries to use your local OS to determine appropriate
line endings, which creates different hash digests on different OSes.

Closes: SCRC-525
Signed-off-by: William Pettersson <william.pettersson@glasgow.ac.uk>