### PR TITLE
Replace scipy with numpy

### DIFF
--- a/simple_network_sim/sampleUseOfModel.py
+++ b/simple_network_sim/sampleUseOfModel.py
@@ -109,7 +109,7 @@ def aggregateResults(results: List[pd.DataFrame]) -> AggregatedResults:
     if len(results) == 1:
         aggregated = results[0]
     else:
-        results = [result.set_index(["time", "node", "age", "state"]).total for result in results]
+        results = [result.set_index(["date", "node", "age", "state"]).total for result in results]
         average = reduce(lambda x, y: x.add(y), results) / len(results)
 
         aggregated = average.reset_index()


### PR DESCRIPTION
Following @FiodorG suggestion to replace scipy with numpy distributions. It seems to be a lot faster, but I still need to write better benchmarks (specially with larger graphs). For the small benchmark I ran, this change alone makes the runtime go from 4 minutes to 2 minutes (the deterministic model is still way faster, at 30s).

I'll see if I can spot other potential speed ups.

Related: https://github.com/ScottishCovidResponse/SCRCIssueTracking/issues/639