### PR TITLE
Signal model issues to the API

### DIFF
--- a/simple_network_sim/common.py
+++ b/simple_network_sim/common.py
@@ -4,16 +4,51 @@ Assortment of useful functions
 # pylint: disable=import-error
 # pylint: disable=duplicate-code
 import logging
-from typing import Callable, Any, NamedTuple
+from enum import Enum
+from typing import Callable, Any, NamedTuple, List
 
 import git  # type: ignore
+from data_pipeline_api import standard_api
 
 logger = logging.getLogger(__name__)
 
 DEFAULT_GITHUB_REPO = "https://github.com/ScottishCovidResponse/simple_network_sim.git"
 
 
-# CurrentlyInUse
+class IssueSeverity(Enum):
+    """
+    This class defines the severity levels for issues found while running the model or loading data.
+    """
+    LOW = 1
+    MEDIUM = 5
+    HIGH = 10
+
+
+def log_issue(
+        logger: logging.Logger,
+        description: str,
+        severity: IssueSeverity,
+        issues: List[standard_api.Issue]
+) -> List[standard_api.Issue]:
+    """
+    Appends issue to the issues list whilst logging its description at the appropriate log level
+
+    :param logger: a python logger object
+    :param description: an explanation of the issue found
+    :param severity: the severity of the issue, from an enum of severities
+    :param issues: list of issues, it will be modified in-place
+    :return: Returns the same list of issues passed as a parameter for convenience
+    """
+    log = {
+        IssueSeverity.LOW: logger.info,
+        IssueSeverity.MEDIUM: logger.warning,
+        IssueSeverity.HIGH: logger.error,
+    }[severity]
+    log(description)
+    issues.append(standard_api.Issue(description=description, severity=severity.value))
+    return issues
+
+
 def generateMeanPlot(listOfPlots):
     """From a list of disease evolution timeseries, compute the average evolution.
 

--- a/simple_network_sim/inference.py
+++ b/simple_network_sim/inference.py
@@ -716,7 +716,7 @@ class ABCSMC:
         :param particle: Particle under consideration
         :return: Model run results for current particle
         """
-        network = ss.createNetworkOfPopulation(
+        network, issues = ss.createNetworkOfPopulation(
             self.compartment_transition_table,
             self.population_table,
             self.commutes_table,
@@ -730,7 +730,11 @@ class ABCSMC:
             self.stochastic_mode,
         )
         random_seed = loaders.readRandomSeed(self.random_seed)
-        results = sm.runSimulation(network, random_seed)
+        results = sm.runSimulation(network, random_seed, issues=issues)
+        if issues:
+            logger.warning("We had %s issues when running the model:", len(issues))
+            for issue in issues:
+                logger.warning("%s (severity: %s)", issue.description, issue.severity)
         aggregated = sm.aggregateResults(results)
         return aggregated.output
 

--- a/simple_network_sim/loaders.py
+++ b/simple_network_sim/loaders.py
@@ -111,8 +111,11 @@ def genGraphFromContactFile(commutes: pd.DataFrame) -> nx.DiGraph:
     """
     G = nx.convert_matrix.from_pandas_edgelist(commutes, edge_attr=True, create_using=nx.DiGraph)
     for edge in G.edges.data():
-        assert edge[2]["weight"] >= 0.0
-        assert edge[2]["delta_adjustment"] >= 0.0
+        if "weight" not in edge[2] or edge[2]["weight"] < 0.0:
+            raise ValueError("missing weight or weight less than zero")
+        if "delta_adjustment" not in edge[2] or edge[2]["delta_adjustment"] < 0.0:
+            raise ValueError("missing delta_adjustment or delta_adjustment less than zero")
+
     return G
 
 
@@ -358,7 +361,7 @@ def readStochasticMode(df: pd.DataFrame) -> bool:
 
 class AgeRange:
     """A helper class for an age range.
-    
+
     The age_group parameter can be any string, but it is usually in the format [a,b) or 70+
     """
 
@@ -414,7 +417,7 @@ class MixingRow:
 
     def __getitem__(self, age: str) -> float:
         """Return expected number of interactions.
-        
+
         Return the expected number of interactions (per day) that someone from
         this MixingRow would have with someone with the given age, or age
         range.
@@ -473,7 +476,7 @@ class MixingMatrix:
 
     def __getitem__(self, age: str) -> MixingRow:
         """Return MixingRow for given age.
-        
+
         Gets a MixingRow for the given age, which in turn can give the
         expected number of interactions. Most often, you will probably want to
         just use MixingMatrix[age1][age2] to get the expected number of

--- a/tests/regression/test_network_of_populations.py
+++ b/tests/regression/test_network_of_populations.py
@@ -28,7 +28,7 @@ def _assert_baseline_dataframe(result, force_update=False):
 
 
 def test_basic_simulation(data_api):
-    network = np.createNetworkOfPopulation(
+    network, _ = np.createNetworkOfPopulation(
         data_api.read_table("human/compartment-transition", "compartment-transition"),
         data_api.read_table("human/population", "population"),
         data_api.read_table("human/commutes", "commutes"),
@@ -40,16 +40,15 @@ def test_basic_simulation(data_api):
         data_api.read_table("human/start-end-date", "start-end-date"),
     )
 
-    result = calculateInfectiousOverTime(
-        np.basicSimulationInternalAgeStructure(network, {"S08000016": {"[17,70)": 10.0}}, numpy.random.default_rng(123)),
-        network.infectiousStates
-    )
+    df, issues = np.basicSimulationInternalAgeStructure(network, {"S08000016": {"[17,70)": 10.0}}, numpy.random.default_rng(123))
+    result = calculateInfectiousOverTime(df, network.infectiousStates)
 
     _assert_baseline(result)
+    assert not issues
 
 
 def test_basic_simulation_with_dampening(data_api):
-    network = np.createNetworkOfPopulation(
+    network, _ = np.createNetworkOfPopulation(
         data_api.read_table("human/compartment-transition", "compartment-transition"),
         data_api.read_table("human/population", "population"),
         data_api.read_table("human/commutes", "commutes"),
@@ -62,16 +61,15 @@ def test_basic_simulation_with_dampening(data_api):
         data_api.read_table("human/movement-multipliers", "movement-multipliers"),
     )
 
-    result = calculateInfectiousOverTime(
-        np.basicSimulationInternalAgeStructure(network, {"S08000016": {"[17,70)": 10.0}}, numpy.random.default_rng(123)),
-        network.infectiousStates,
-    )
+    df, issues = np.basicSimulationInternalAgeStructure(network, {"S08000016": {"[17,70)": 10.0}}, numpy.random.default_rng(123))
+    result = calculateInfectiousOverTime(df, network.infectiousStates)
 
     _assert_baseline(result)
+    assert not issues
 
 
 def test_basic_simulation_stochastic(data_api_stochastic):
-    network = np.createNetworkOfPopulation(
+    network, _ = np.createNetworkOfPopulation(
         data_api_stochastic.read_table("human/compartment-transition", "compartment-transition"),
         data_api_stochastic.read_table("human/population", "population"),
         data_api_stochastic.read_table("human/commutes", "commutes"),
@@ -85,13 +83,14 @@ def test_basic_simulation_stochastic(data_api_stochastic):
         data_api_stochastic.read_table("human/stochastic-mode", "stochastic-mode"),
     )
     seed = loaders.readRandomSeed(data_api_stochastic.read_table("human/random-seed", "random-seed"))
-    result = np.basicSimulationInternalAgeStructure(network, {"S08000016": {"[17,70)": 10}}, numpy.random.default_rng(seed))
+    result, issues = np.basicSimulationInternalAgeStructure(network, {"S08000016": {"[17,70)": 10}}, numpy.random.default_rng(seed))
 
     _assert_baseline_dataframe(result)
+    assert not issues
 
 
 def test_basic_simulation_100_runs(data_api):
-    network = np.createNetworkOfPopulation(
+    network, _ = np.createNetworkOfPopulation(
         data_api.read_table("human/compartment-transition", "compartment-transition"),
         data_api.read_table("human/population", "population"),
         data_api.read_table("human/commutes", "commutes"),
@@ -105,15 +104,16 @@ def test_basic_simulation_100_runs(data_api):
 
     runs = []
     rand = random.Random(1)
+    issues = []
     for _ in range(100):
         regions = rand.choices(list(network.graph.nodes()), k=1)
         assert network.initialState[regions[0]][("[17,70)", "E")] == 0
-        result = calculateInfectiousOverTime(
-            np.basicSimulationInternalAgeStructure(network, {regions[0]: {"[17,70)": 10.0}}, numpy.random.default_rng(123)),
-            network.infectiousStates,
-        )
+        df, new_issues = np.basicSimulationInternalAgeStructure(network, {regions[0]: {"[17,70)": 10.0}}, numpy.random.default_rng(123))
+        result = calculateInfectiousOverTime(df, network.infectiousStates)
         result.pop()  # TODO: due to historical reasons we have to ignore the last entry
         runs.append(result)
+        issues.extend(new_issues)
     result = common.generateMeanPlot(runs)
 
     _assert_baseline(result)
+    assert not issues

--- a/tests/regression/test_sampleUseOfModel.py
+++ b/tests/regression/test_sampleUseOfModel.py
@@ -53,7 +53,7 @@ def test_stochastic_cli_run(base_data_dir):
 
 
 def test_stochastic_seed_sequence(data_api_stochastic):
-    network = network_of_populations.createNetworkOfPopulation(
+    network, _ = network_of_populations.createNetworkOfPopulation(
         data_api_stochastic.read_table("human/compartment-transition", "compartment-transition"),
         data_api_stochastic.read_table("human/population", "population"),
         data_api_stochastic.read_table("human/commutes", "commutes"),
@@ -67,7 +67,9 @@ def test_stochastic_seed_sequence(data_api_stochastic):
         pd.DataFrame({"Value": [True]}),
     )
 
-    df1, df2 = sampleUseOfModel.runSimulation(network, random_seed=123, max_workers=2)
+    issues = []
+    df1, df2 = sampleUseOfModel.runSimulation(network, random_seed=123, issues=issues, max_workers=2)
 
     # It's very unlikely these numbers would match unless both runs produce the same numbers
     assert df1[df1.state == "D"].total.sum() != df2[df2.state == "D"].total.sum()
+    assert not issues

--- a/tests/unit/test_common.py
+++ b/tests/unit/test_common.py
@@ -1,9 +1,11 @@
 import os
+from unittest import mock
 
 import git
 import pytest
+from data_pipeline_api import standard_api
 
-from simple_network_sim.common import Lazy, get_repo_info
+from simple_network_sim.common import Lazy, get_repo_info, log_issue, IssueSeverity
 
 
 def test_lazy_never_evaluated():
@@ -77,3 +79,30 @@ def test_get_repo_info_no_repo(no_git_repo):
     assert info.is_dirty
     assert info.git_sha == ""
     assert info.uri == "https://github.com/ScottishCovidResponse/simple_network_sim.git"
+
+
+def test_log_low_issue():
+    logger = mock.MagicMock()
+    issues = []
+    log_issue(logger, "hi", IssueSeverity.LOW, issues)
+
+    assert issues == [standard_api.Issue(description="hi", severity=1)]
+    logger.info.assert_called_once_with("hi")
+
+
+def test_log_medium_issue():
+    logger = mock.MagicMock()
+    issues = []
+    log_issue(logger, "hi", IssueSeverity.MEDIUM, issues)
+
+    assert issues == [standard_api.Issue(description="hi", severity=5)]
+    logger.warning.assert_called_once_with("hi")
+
+
+def test_log_high_issue():
+    logger = mock.MagicMock()
+    issues = []
+    log_issue(logger, "hi", IssueSeverity.HIGH, issues)
+
+    assert issues == [standard_api.Issue(description="hi", severity=10)]
+    logger.error.assert_called_once_with("hi")

--- a/tests/unit/test_loaders.py
+++ b/tests/unit/test_loaders.py
@@ -158,7 +158,7 @@ def test_genGraphFromContactFile_negative_delta_adjustment():
     df = pd.DataFrame([
         {"source": "a", "target": "b", "weight": 0, "delta_adjustment": -1.0}
     ])
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError):
         loaders.genGraphFromContactFile(df)
 
 
@@ -167,7 +167,25 @@ def test_genGraphFromContactFile_negative_weight():
         {"source": "a", "target": "b", "weight": -30.0, "delta_adjustment": 1.0}
     ])
 
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError):
+        loaders.genGraphFromContactFile(df)
+
+
+def test_genGraphFromContactFile_missing_weight():
+    df = pd.DataFrame([
+        {"source": "a", "target": "b", "delta_adjustment": 1.0}
+    ])
+
+    with pytest.raises(ValueError):
+        loaders.genGraphFromContactFile(df)
+
+
+def test_genGraphFromContactFile_missing_adjustmentt():
+    df = pd.DataFrame([
+        {"source": "a", "target": "b", "weight": 30.0}
+    ])
+
+    with pytest.raises(ValueError):
         loaders.genGraphFromContactFile(df)
 
 


### PR DESCRIPTION
Closes: https://github.com/ScottishCovidResponse/SCRCIssueTracking/issues/689

My design decision here was to return a list of issues in the run model function, as that one is run in parallel. Internally, I just pass the list as that's more convenient, and from my tests, parallelising it internally doesn't make much sense as things are currently.

The only issue we can raise is during the model run to condition that should never happen. In the data loading part we can raise issues when either nodes or connections are missing. I've arbritarily chose to classify the severities in LOW (haven't used that one) MEDIUM (I associated warnings with that) and HIGH (I associated errors with that).

Moreover, since we were already failing to load graphs without `weight`s  or `delta_adjustment`s, I've removed that check from the model and made the check in the loaders more explicit.